### PR TITLE
Generated JWT secret is too small for HMAC SHA256

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Follow [these steps](#installing-mysql) to install MySQL server.
 
 JWT secret defines the secret key to validate the JSON Web Token in the request to the **ONLYOFFICE Document Server**. You can specify it yourself or easily get it using the command:
 ```
-JWT_SECRET=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 12);
+JWT_SECRET=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 32);
 ```
 
 **STEP 4**: Install ONLYOFFICE Document Server.


### PR DESCRIPTION
Detailed information is provided in this pull request - https://github.com/ONLYOFFICE/Docker-DocumentServer/pull/557